### PR TITLE
WIP, auth key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,8 @@ jobs:
         run: pip3 install ansible molecule[docker] docker
 
       - name: Run Molecule tests.
-        run: molecule test
+        run: |
+          TAILSCALE_AUTHORIZE_KEY=${{ secrets.TAILSCALE_AUTHORIZE_KEY }} molecule test
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/.yamllint
+++ b/.yamllint
@@ -3,7 +3,7 @@ extends: default
 
 rules:
   line-length:
-    max: 120
+    max: 180
     level: warning
   truthy:
     ignore: |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ The release stage to use for downloading. There are two release stages, `stable`
 
 Apt repository options for tailscale installation.
 
+    tailscaled_daemon_state: started
+    tailscaled_daemon_enabled: true
+
+Configure the state of the tailscaled deamon.
+
+    tailscale_authorize_daemon: true
+
+Run the authorize command.
+
+    tailscale_authorize_key: "tskey-abcdef1234567890"
+
+Use the following key when authorizing.
+
+    tailscale_authorize_timeout: 10
+
+Timeout to wait for the authorize command to complete.
+
 ## Dependencies
 
 None.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ None.
 
       vars:
         tailscale_apt_release_stage: "stable"
+        tailscale_authorize_key: "tskey-abcdef1234567890"
 
       roles:
         - jason_riddle.tailscale

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,10 @@ tailscale_apt_release_stage: "stable"
 tailscale_apt_key: "https://pkgs.tailscale.com/{{ tailscale_apt_release_stage }}/{{ ansible_distribution|lower }}/{{ ansible_distribution_release|lower }}.gpg"
 tailscale_apt_repository: "deb https://pkgs.tailscale.com/{{ tailscale_apt_release_stage }}/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} main"
 tailscale_apt_ignore_key_error: false
+
+tailscaled_daemon_state: started
+tailscaled_daemon_enabled: true
+
+tailscale_authorize_daemon: true
+tailscale_authorize_key: "tskey-abcdef1234567890"
+tailscale_authorize_timeout: 10

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,6 +3,9 @@
   hosts: all
   become: true
 
+  vars:
+    tailscale_authorize_key: "{{ lookup('env', 'TAILSCALE_AUTHORIZE_KEY') }}"
+
   pre_tasks:
     - name: Update apt cache.
       apt: update_cache=true cache_valid_time=600

--- a/tasks/authorize.yml
+++ b/tasks/authorize.yml
@@ -1,0 +1,14 @@
+---
+- name: Assert tailscale_authorize_key is not empty.
+  assert:
+    that:
+      - tailscale_authorize_key | length > 0
+    quiet: true
+
+- name: Run the authorize command.
+  become: true
+  command: "tailscale up --authkey {{ tailscale_authorize_key }}"
+  async: "{{ tailscale_authorize_timeout }}"
+  poll: 1
+  tags:
+    - molecule-idempotence-notest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,3 +15,12 @@
   apt:
     name: tailscale
     state: present
+
+- name: Ensure tailscaled is running as desired.
+  service:
+    name: tailscaled
+    state: "{{ tailscaled_daemon_state }}"
+    enabled: "{{ tailscaled_daemon_enabled }}"
+
+- include_tasks: authorize.yml
+  when: tailscale_authorize_daemon


### PR DESCRIPTION
Adds the ability to authorize with `tailscale_authorize_key`.