### PR TITLE
Read the auth key from stdin

### DIFF
--- a/tasks/authorize.yml
+++ b/tasks/authorize.yml
@@ -7,7 +7,9 @@
 
 - name: Run the authorize command.
   become: true
-  command: "tailscale up --authkey {{ tailscale_authorize_key }}"
+  command: "tailscale up --authkey=file:/dev/stdin"
+  args:
+    stdin: "{{ tailscale_authorize_key }}"
   async: "{{ tailscale_authorize_timeout }}"
   poll: 1
   tags:


### PR DESCRIPTION
Read the auth key from stdin. If `ANSIBLE_DEBUG=1` is set, then stdin will be shown. Also, `ANSIBLE_VERBOSITY=1` did not reveal the key, but `ANSIBLE_VERBOSITY=4` might. Overall this feels more secure.