### PR TITLE
Disable serve and funnel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,18 +101,24 @@ jobs:
           MOLECULE_PLAYBOOK: ${{ matrix.playbook }}
           TAILSCALE_AUTHKEY: "${{ secrets.TAILSCALE_AUTHKEY }}"
 
-      - name: Run Molecule serve test.
-        run: |
-          molecule test --scenario-name serve
-        env:
-          MOLECULE_DISTRO: ${{ matrix.distro }}
-          MOLECULE_PLAYBOOK: ${{ matrix.playbook }}
-          TAILSCALE_AUTHKEY: "${{ secrets.TAILSCALE_AUTHKEY }}"
+      # TODO: serve and funnel command line arguments have changed.
+      # See https://tailscale.com/blog/reintroducing-serve-funnel/.
 
-      - name: Run Molecule funnel test.
-        run: |
-          molecule test --scenario-name funnel
-        env:
-          MOLECULE_DISTRO: ${{ matrix.distro }}
-          MOLECULE_PLAYBOOK: ${{ matrix.playbook }}
-          TAILSCALE_AUTHKEY: "${{ secrets.TAILSCALE_AUTHKEY }}"
+      # - name: Run Molecule serve test.
+      #   run: |
+      #     molecule test --scenario-name serve
+      #   env:
+      #     MOLECULE_DISTRO: ${{ matrix.distro }}
+      #     MOLECULE_PLAYBOOK: ${{ matrix.playbook }}
+      #     TAILSCALE_AUTHKEY: "${{ secrets.TAILSCALE_AUTHKEY }}"
+
+      # TODO: serve and funnel command line arguments have changed.
+      # See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
+      # - name: Run Molecule funnel test.
+      #   run: |
+      #     molecule test --scenario-name funnel
+      #   env:
+      #     MOLECULE_DISTRO: ${{ matrix.distro }}
+      #     MOLECULE_PLAYBOOK: ${{ matrix.playbook }}
+      #     TAILSCALE_AUTHKEY: "${{ secrets.TAILSCALE_AUTHKEY }}"

--- a/README.md
+++ b/README.md
@@ -8,8 +8,14 @@ Features:
 - Install Tailscale.
 - Register Node to Tailnet.
 - (Beta Feature) Provision HTTPS certificates.
+
+<!--
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
 - (Beta Feature) Serve Content.
 - (Beta Feature) Funnel.
+-->
 
 ## Requirements
 
@@ -57,6 +63,11 @@ Run `tailscale cert` with arguments. `tailscale_cert_domain` must be set.
 
 See https://tailscale.com/kb/1153/enabling-https/.
 
+<!--
+
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
     tailscale_serve_enabled: false
     tailscale_serve_content: []
     # You can specify multiple items to serve.
@@ -69,6 +80,9 @@ See https://tailscale.com/kb/1153/enabling-https/.
 Run `tailscale serve` with arguments.
 
 See https://tailscale.com/kb/1242/tailscale-serve/.
+
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
 
     tailscale_funnel_enabled: false
     tailscale_funnel_ports_enabled: []
@@ -83,6 +97,8 @@ See https://tailscale.com/kb/1242/tailscale-serve/.
 Run `tailscale funnel` with arguments.
 
 See https://tailscale.com/kb/1223/tailscale-funnel/ and https://tailscale.com/kb/1247/funnel-serve-use-cases/.
+
+-->
 
     tailscale_default_options_enabled: false
     tailscale_default_options_settings:
@@ -148,6 +164,11 @@ See https://tailscale.com/kb/1153/enabling-https/.
     - jason_riddle.tailscale
 ```
 
+<!--
+
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
 ### (Beta Feature) Serve Content.
 
 See https://tailscale.com/kb/1242/tailscale-serve/.
@@ -167,6 +188,9 @@ See https://tailscale.com/kb/1242/tailscale-serve/.
     - jason_riddle.tailscale
 ```
 
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
 ### (Beta Feature) Funnel.
 
 See https://tailscale.com/kb/1223/tailscale-funnel/.
@@ -185,6 +209,8 @@ See https://tailscale.com/kb/1223/tailscale-funnel/.
   roles:
     - jason_riddle.tailscale
 ```
+
+-->
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,9 @@ tailscale_cert_filename: "{{ tailscale_cert_domain }}.crt"
 tailscale_cert_private_key_dir: "/usr/local/etc/ssl/private"
 tailscale_cert_private_key_filename: "{{ tailscale_cert_domain }}.key"
 
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
 # Serve options.
 tailscale_serve_enabled: false
 tailscale_serve_content: []
@@ -34,6 +37,9 @@ tailscale_serve_content: []
 # See https://tailscale.com/kb/1242/tailscale-serve/#examples for all examples.
 # To serve simple static text
 #   - "http / text:'Hello, world!'"
+
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
 
 # Funnel options.
 tailscale_funnel_enabled: false

--- a/molecule/funnel/converge.yml
+++ b/molecule/funnel/converge.yml
@@ -1,4 +1,7 @@
 ---
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
 - name: Converge
   hosts: all
   become: true

--- a/molecule/funnel/molecule.yml
+++ b/molecule/funnel/molecule.yml
@@ -1,4 +1,7 @@
 ---
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
 dependency:
   name: galaxy
 driver:

--- a/molecule/funnel/verify.yml
+++ b/molecule/funnel/verify.yml
@@ -1,4 +1,7 @@
 ---
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
 - name: Verify
   hosts: all
 

--- a/molecule/serve/converge.yml
+++ b/molecule/serve/converge.yml
@@ -1,4 +1,7 @@
 ---
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
 - name: Converge
   hosts: all
   become: true

--- a/molecule/serve/molecule.yml
+++ b/molecule/serve/molecule.yml
@@ -1,4 +1,7 @@
 ---
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
 dependency:
   name: galaxy
 driver:

--- a/molecule/serve/verify.yml
+++ b/molecule/serve/verify.yml
@@ -1,4 +1,7 @@
 ---
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
 - name: Verify
   hosts: all
 

--- a/tasks/funnel.yml
+++ b/tasks/funnel.yml
@@ -1,7 +1,10 @@
 ---
-- name: Funnel each port in tailscale_funnel_ports_enabled.
-  command: |
-    tailscale funnel {{ item }} on
-  tags:
-    - molecule-idempotence-notest
-  with_items: "{{ tailscale_funnel_ports_enabled }}"
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
+# - name: Funnel each port in tailscale_funnel_ports_enabled.
+#   command: |
+#     tailscale funnel {{ item }} on
+#   tags:
+#     - molecule-idempotence-notest
+#   with_items: "{{ tailscale_funnel_ports_enabled }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,10 +35,16 @@
   include_tasks: cert.yml
   when: tailscale_cert_enabled | bool
 
-- name: Include serve.yml
-  include_tasks: serve.yml
-  when: tailscale_serve_enabled | bool
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
 
-- name: Include funnel.yml
-  include_tasks: funnel.yml
-  when: tailscale_funnel_enabled | bool
+# - name: Include serve.yml
+#   include_tasks: serve.yml
+#   when: tailscale_serve_enabled | bool
+
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
+# - name: Include funnel.yml
+#   include_tasks: funnel.yml
+#   when: tailscale_funnel_enabled | bool

--- a/tasks/serve.yml
+++ b/tasks/serve.yml
@@ -1,7 +1,10 @@
 ---
-- name: Serve each content item in tailscale_serve_content.
-  command: |
-    tailscale serve {{ item }}
-  with_items: "{{ tailscale_serve_content }}"
-  tags:
-    - molecule-idempotence-notest
+# TODO: serve and funnel command line arguments have changed.
+# See https://tailscale.com/blog/reintroducing-serve-funnel/.
+
+# - name: Serve each content item in tailscale_serve_content.
+#   command: |
+#     tailscale serve {{ item }}
+#   with_items: "{{ tailscale_serve_content }}"
+#   tags:
+#     - molecule-idempotence-notest


### PR DESCRIPTION
The serve and funnel command line arguments have changed, so remove both features.

See https://tailscale.com/blog/reintroducing-serve-funnel/.