### PR TITLE
Add ARM64 testing support to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,12 @@ jobs:
 
   molecule:
     name: Molecule
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
+        runner:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
         distro:
           # See: https://www.jeffgeerling.com/blog/2024/newer-versions-ansible-dont-work-rhel-8
           # - rockylinux8


### PR DESCRIPTION
## Summary
- Add ARM64 runner support by including `ubuntu-24.04-arm` in the CI test matrix
- Leverage GitHub's new ARM64 runner capabilities for comprehensive testing across architectures

## Test plan
- [x] Updated CI workflow to include ARM64 runner alongside existing ubuntu-latest
- [ ] Verify CI passes on both x86_64 and ARM64 architectures
- [ ] Confirm all molecule test scenarios work on ARM64

Fixes #111

🤖 Generated with [Claude Code](https://claude.ai/code)