### PR TITLE
Add example OIDC workflow

### DIFF
--- a/.github/workflows/example-oidc.yml
+++ b/.github/workflows/example-oidc.yml
@@ -1,0 +1,100 @@
+---
+# Example: Using Tailscale with OIDC Authentication in GitHub Actions
+#
+# This workflow demonstrates how to use OIDC (OpenID Connect) to automatically
+# generate Tailscale auth keys without storing long-lived secrets.
+#
+# Prerequisites:
+# 1. Configure Tailscale Trust Credential (see .github/docs/OIDC_SETUP.md)
+# 2. Set repository secrets:
+#    - TS_V2_OIDC_CLIENT_ID: Your Tailscale OIDC client ID
+#    - TS_V2_OIDC_AUDIENCE: Your custom audience (e.g., "tailscale-ci")
+#
+# For complete setup instructions, see: .github/docs/OIDC_SETUP.md
+
+name: Example OIDC Workflow
+
+on:
+  workflow_dispatch:  # Manual trigger for testing
+
+permissions:
+  contents: read      # Required for actions/checkout
+  id-token: write     # Required for OIDC token generation
+
+jobs:
+  tailscale-oidc-example:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      # Step 1: Get OIDC token from GitHub
+      - name: Get GitHub OIDC token
+        id: get_oidc_token
+        run: |
+          OIDC_TOKEN=$(curl -sS -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${{ secrets.TS_V2_OIDC_AUDIENCE }}" | jq -r '.value')
+          echo "token=$OIDC_TOKEN" >> $GITHUB_OUTPUT
+          echo "::add-mask::$OIDC_TOKEN"
+
+      # Step 2: Exchange OIDC token for Tailscale API token
+      - name: Exchange OIDC token for Tailscale API token
+        id: get_ts_api_token
+        run: |
+          RESPONSE=$(curl -sS -X POST https://api.tailscale.com/api/v2/oauth/token-exchange \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "client_id=${{ secrets.TS_V2_OIDC_CLIENT_ID }}" \
+            -d "jwt=${{ steps.get_oidc_token.outputs.token }}")
+          ACCESS_TOKEN=$(echo "$RESPONSE" | jq -r '.access_token')
+          if [ "$ACCESS_TOKEN" = "null" ] || [ -z "$ACCESS_TOKEN" ]; then
+            echo "Failed to get Tailscale API token. Check OIDC configuration."
+            exit 1
+          fi
+          echo "access_token=$ACCESS_TOKEN" >> $GITHUB_OUTPUT
+          echo "::add-mask::$ACCESS_TOKEN"
+
+      # Step 3: Generate ephemeral Tailscale auth key
+      - name: Generate ephemeral Tailscale auth key
+        id: generate_authkey
+        run: |
+          RESPONSE=$(curl -sS -X POST https://api.tailscale.com/api/v2/tailnet/-/keys \
+            -H "Authorization: Bearer ${{ steps.get_ts_api_token.outputs.access_token }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "capabilities": {
+                "devices": {
+                  "create": {
+                    "reusable": false,
+                    "ephemeral": true,
+                    "preauthorized": true,
+                    "tags": ["tag:github-actions"]
+                  }
+                }
+              },
+              "expirySeconds": 3600
+            }')
+          AUTH_KEY=$(echo "$RESPONSE" | jq -r '.key')
+          if [ "$AUTH_KEY" = "null" ] || [ -z "$AUTH_KEY" ]; then
+            echo "Failed to generate auth key. Check API token permissions and Tailscale ACL configuration."
+            exit 1
+          fi
+          echo "key=$AUTH_KEY" >> $GITHUB_OUTPUT
+          echo "::add-mask::$AUTH_KEY"
+
+      # Step 4: Use the generated auth key with your Ansible role
+      - name: Run ansible playbook with Tailscale
+        run: |
+          # Your ansible playbook execution here
+          # The TAILSCALE_AUTHKEY is available as an environment variable
+          echo "Auth key successfully generated!"
+          echo "You can now use it in your Ansible playbook"
+        env:
+          TAILSCALE_AUTHKEY: ${{ steps.generate_authkey.outputs.key }}
+
+      # Alternative: Use with Tailscale GitHub Action
+      - name: Connect to Tailscale (using official action)
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_V2_OIDC_CLIENT_ID }}
+          oauth-secret: ${{ steps.get_ts_api_token.outputs.access_token }}
+          tags: tag:github-actions


### PR DESCRIPTION
Add an example GitHub Actions workflow demonstrating OIDC authentication with Tailscale.

This workflow shows how to:
- Generate OIDC tokens from GitHub Actions
- Exchange them for Tailscale API tokens
- Create ephemeral auth keys for CI testing
- Use both direct auth keys and the official Tailscale GitHub Action

The example uses GitHub secrets for enhanced security and includes proper error handling.

Based on main branch with clean commit history.