### PR TITLE
fix: replace apt_key with get_url + signed-by for Debian 13 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,21 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    tailscale_apt_gpg_key: "https://pkgs.tailscale.com/stable/{{ ansible_distribution|lower }}/{{ ansible_distribution_release|lower }}.gpg"
+    tailscale_apt_gpg_key: "https://pkgs.tailscale.com/stable/{{ ansible_distribution|lower }}/{{ ansible_distribution_release|lower }}.noarmor.gpg"
     tailscale_apt_repository: "deb https://pkgs.tailscale.com/stable/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} main"
 
 Apt repository options for Tailscale installation.
+
+> **Note (2026-06-09):** The key installation method was updated from the
+> deprecated `apt_key` module to `get_url` + `apt_repository` with `signed-by`
+> (see [issue #153](https://github.com/jason-riddle/ansible-role-tailscale/issues/153)).
+> `ansible.builtin.apt_key` was removed in ansible-core 2.17, which caused a
+> fatal error on Debian 13 (Trixie) and any other system running
+> ansible-core >= 2.17. The replacement approach uses only `get_url` and
+> `apt_repository`, both of which are available in all supported ansible-core
+> versions, so backwards compatibility is maintained. The key URL was also
+> changed from `.gpg` (ASCII-armored) to `.noarmor.gpg` (binary), which is
+> required by the `signed-by` apt option.
 
     __ts_yum_centos_repo_url: "https://pkgs.tailscale.com/stable/centos/{{ ansible_distribution_major_version }}/tailscale.repo"
     __ts_yum_fedora_repo_url: "https://pkgs.tailscale.com/stable/fedora/tailscale.repo"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,15 @@
 ---
 # Used only for Debian/Ubuntu.
-tailscale_apt_gpg_key: "https://pkgs.tailscale.com/stable/{{ ansible_distribution|lower }}/{{ ansible_distribution_release|lower }}.gpg"
+#
+# Changed from .gpg to .noarmor.gpg (2026-06-09, see issue #153).
+# The .gpg URL served an ASCII-armored key, which is not accepted by the
+# signed-by option in modern apt. The .noarmor.gpg URL serves the same key
+# in binary (non-armored) format, which apt requires when the key is
+# referenced via signed-by in a sources.list entry.
+# apt_key (which handled the conversion internally) was removed in
+# ansible-core 2.17; the replacement get_url + signed-by approach needs the
+# binary format explicitly.
+tailscale_apt_gpg_key: "https://pkgs.tailscale.com/stable/{{ ansible_distribution|lower }}/{{ ansible_distribution_release|lower }}.noarmor.gpg"
 tailscale_apt_repository: "deb https://pkgs.tailscale.com/stable/{{ ansible_distribution|lower }} {{ ansible_distribution_release|lower }} main"
 
 # Used only for RedHat/CentOS/Fedora.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,8 @@ galaxy_info:
       versions:
         - buster   # Debian 10
         - bullseye # Debian 11
+        - bookworm # Debian 12
+        - trixie   # Debian 13
     - name: Ubuntu
       versions:
         - bionic # Ubuntu 18.04

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -11,13 +11,34 @@
     state: present
   when: ansible_distribution == 'Ubuntu' or ansible_distribution_version is version('20.04', '>=')
 
-- name: Add tailscale apt key.
-  apt_key:
-    url: "{{ tailscale_apt_gpg_key }}"
-    state: present
+# Ensure /etc/apt/keyrings exists. It is present by default on Debian 12+
+# and Ubuntu 22.04+, but older releases may not have it.
+- name: Ensure /etc/apt/keyrings directory exists.
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
 
+# ansible.builtin.apt_key was deprecated in ansible-core 2.16 and removed in
+# ansible-core 2.17. Debian 13 (Trixie) and newer distros ship with
+# ansible-core >= 2.17, causing a fatal "couldn't resolve module" error.
+# Replaced with ansible.builtin.get_url, which has been available since
+# Ansible 2.0 and works on all supported ansible-core versions.
+- name: Download Tailscale apt signing key.
+  ansible.builtin.get_url:
+    url: "{{ tailscale_apt_gpg_key }}"
+    dest: /etc/apt/keyrings/tailscale.asc
+    owner: root
+    group: root
+    mode: "0644"
+
+# Use the signed-by option so apt validates packages against the key stored
+# at /etc/apt/keyrings/tailscale.asc rather than relying on the global
+# apt trusted keyring (the old behaviour when apt_key was used).
 - name: Add tailscale apt repository.
-  apt_repository:
-    repo: "{{ tailscale_apt_repository }}"
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by=/etc/apt/keyrings/tailscale.asc] {{ tailscale_apt_repository }}"
     state: present
     update_cache: true


### PR DESCRIPTION
## Description

Replace the deprecated `ansible.builtin.apt_key` (removed in ansible-core 2.17) with `get_url` + `apt_repository` using `signed-by`, fixing the fatal error on Debian 13 (Trixie) and any system running ansible-core >= 2.17.

Both `get_url` and `apt_repository` have been available since Ansible 2.0, so backwards compatibility with older ansible-core versions is fully preserved.

## Changes

- **`tasks/setup-Debian.yml`** — Ensure `/etc/apt/keyrings` exists; download signing key via `get_url` to `/etc/apt/keyrings/tailscale.asc`; update `apt_repository` to use `deb [signed-by=...] ...`
- **`defaults/main.yml`** — `tailscale_apt_gpg_key` URL: `.gpg` → `.noarmor.gpg` (binary format required by `signed-by`)
- **`meta/main.yml`** — Add Debian 12 (bookworm) and Debian 13 (trixie) to supported platforms
- **`README.md`** — Update variable example; add note explaining the change

## Related

Fixes #153